### PR TITLE
python 3 compatibility

### DIFF
--- a/bmp2array.py
+++ b/bmp2array.py
@@ -39,19 +39,19 @@ infile.close()
 data = [contents[2], contents[3], contents[4], contents[5]]
 fileSize = struct.unpack("I", bytearray(data))
 
-print "Size of file:", fileSize[0]
+print("Size of file:", fileSize[0])
 
 #Get the header offset amount
 data = [contents[10], contents[11], contents[12], contents[13]]
 offset = struct.unpack("I", bytearray(data))
 
-print "Offset:", offset[0]
+print("Offset:", offset[0])
 
 #Get the number of colors used
 data = [contents[46], contents[47], contents[48], contents[49]]
 colorsUsed = struct.unpack("I", bytearray(data))
 
-print "Number of colors used:", colorsUsed[0]
+print("Number of colors used:", colorsUsed[0])
 
 #Create color definition array and init the array of color values
 colorIndex = bytearray(colorsUsed[0])
@@ -104,5 +104,5 @@ outfile = open("output.txt","w")
 outfile.write(outputString)
 outfile.close()
 
-print "output.txt complete"
-print "Copy and paste this array into a image.h or other header file"
+print("output.txt complete")
+print("Copy and paste this array into a image.h or other header file")

--- a/bmp2array.py
+++ b/bmp2array.py
@@ -68,7 +68,7 @@ for i in range(colorsUsed[0]):
     #print hexlify(colorIndex[i])
 
 #Make a string to hold the output of our script
-arraySize = (len(contents) - offset[0]) / 2
+arraySize = int((len(contents) - offset[0]) / 2)
 outputString = "/* This was generated using the SparkFun BMPtoArray python script" + '\r'
 outputString += " See https://github.com/sparkfun/BMPtoArray for more info */" + '\r\r'
 outputString += "static const unsigned char myGraphic[" + str(arraySize) + "] PROGMEM = {" + '\r'

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This script takes in a bitmap and converts the bitmap into 4-bit grayscale. An a
 
 This is very useful if you have a bitmap that you'd like to output onto a grayscale display (like the SparkFun flexible OLED). I attempted to use the bitmap2lcd program but found it very hard to use and over blown (and costs money) to generate an image array.
 
-Three bitmaps are provided as an example. Requires python v2.7.
+Three bitmaps are provided as an example. Requires python v2.7+.
 
 **To use your own image:**
 


### PR DESCRIPTION
Identical output is produced with:
- Python 2.7.17, `python bmp2array.py macaque.bmp`) on master
- Python 2.7.17, `python bmp2array.py macaque.bmp`) on this PR (f503f9a7b2a81f9e568fc472eb6387278299f9ec)
- Python 3.8.5, `python3 bmp2array.py macaque.bmp`) on this PR (f503f9a7b2a81f9e568fc472eb6387278299f9ec)
